### PR TITLE
Pass the user to the callback

### DIFF
--- a/src/Verifi.php
+++ b/src/Verifi.php
@@ -161,7 +161,7 @@ class Verifi {
             // Dispatch the invalid credentials event
             $this->dispatcher->dispatch(new InvalidCredentials(null));
 
-            return call_user_func($callback, $user);
+            return call_user_func($callback, null);
         }
 
         // Dispatch the verified event

--- a/src/Verifi.php
+++ b/src/Verifi.php
@@ -161,7 +161,7 @@ class Verifi {
             // Dispatch the invalid credentials event
             $this->dispatcher->dispatch(new InvalidCredentials(null));
 
-            return call_user_func($callback);
+            return call_user_func($callback, $user);
         }
 
         // Dispatch the verified event


### PR DESCRIPTION
The user is currently not being passed to the callback in case of a verification failure (INVALID_CREDENTIALS). So currently this: 
```php
<?php
Verifi::verify(request(), function ($user) {
  //verification logic
});
```
will result in 
> (1/1) FatalThrowableError
Type error: Too few arguments to function App\Http\Controllers\Auth\VerifyController::App\Http\Controllers\Auth\{closure}(), 0 passed and exactly 1 expected

and the developer would have to make the user param optional, like below
```php
<?php
Verifi::verify(request(), function ($user = null) {
   //verification logic
});
```