### PR TITLE
Use isEmailVerified in the IsEmailVerified middleware

### DIFF
--- a/src/Http/Middleware/IsEmailVerified.php
+++ b/src/Http/Middleware/IsEmailVerified.php
@@ -20,7 +20,7 @@ class IsEmailVerified {
      */
     public function handle($request, Closure $next) {
 
-        if (!is_null($request->user()) && !$request->user()->isVerified()) {
+        if (!is_null($request->user()) && !$request->user()->isEmailVerified()) {
             throw new UserNotVerifiedException();
         }
 


### PR DESCRIPTION
Currently we're just calling `isVerified()` which fails because the Verifi contract specifies an `isEmailVerified()` method.